### PR TITLE
Set Catppuccin as default theme

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,4 +2,4 @@
 require("config.lazy")
 
 -- Set default colorscheme
-vim.cmd.colorscheme("everforest")
+vim.cmd.colorscheme("catppuccin")


### PR DESCRIPTION
This pull request includes a small change to the `init.lua` file. The change sets the default colorscheme from "everforest" to "catppuccin".